### PR TITLE
feat: use map_viz endpoint in eea.api.dataconnector #254131

### DIFF
--- a/src/components/Blocks/EmbedEEAMap/Edit.jsx
+++ b/src/components/Blocks/EmbedEEAMap/Edit.jsx
@@ -4,8 +4,6 @@ import { SidebarPortal } from '@plone/volto/components';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { getContent } from '@plone/volto/actions';
-
 import BlockDataForm from '@plone/volto/components/manage/Form/BlockDataForm';
 import Webmap from '@eeacms/volto-eea-map/components/Webmap';
 import ExtraViews from '@eeacms/volto-eea-map/components/ExtraViews';
@@ -16,15 +14,10 @@ import {
   updateBlockQueryFromPageQuery,
 } from '@eeacms/volto-eea-map/utils';
 
+import { getVisualization } from '@eeacms/volto-eea-map/actions';
+
 const Edit = (props) => {
-  const {
-    block,
-    data,
-    onChangeBlock,
-    selected,
-    id,
-    data_provenance = {},
-  } = props;
+  const { block, data, onChangeBlock, selected, data_provenance = {} } = props;
   const { height = '' } = data;
   const schema = Schema(props);
   const [mapData, setMapData] = React.useState('');
@@ -52,7 +45,7 @@ const Edit = (props) => {
   }, [data.show_legend, data.show_sources, data.dataprotection]);
 
   React.useEffect(() => {
-    props.getContent(props.data.vis_url, null, id);
+    props.getVisualization(props.data.vis_url);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.data.vis_url]);
 
@@ -132,13 +125,15 @@ export default compose(
   connect(
     (state, props) => ({
       data_query: state.content.data.data_query,
-      data_provenance:
-        state.content.subrequests?.[props.id]?.data?.data_provenance,
-      map_visualization:
-        state.content.subrequests?.[props.id]?.data?.map_visualization_data,
+      map_visualization: props.data.vis_url
+        ? state.map_visualizations?.data[props.data.vis_url]?.data
+        : '',
+      data_provenance: props.data.vis_url
+        ? state.map_visualizations?.data[props.data.vis_url]?.data_provenance
+        : '',
     }),
     {
-      getContent,
+      getVisualization,
     },
   ),
 )(Edit);

--- a/src/components/Blocks/EmbedEEAMap/Edit.jsx
+++ b/src/components/Blocks/EmbedEEAMap/Edit.jsx
@@ -84,7 +84,11 @@ const Edit = (props) => {
     setMapData(updatedMapData);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.map_visualization, props.data]);
+  }, [
+    props.map_visualization,
+    props.data.data_query_params,
+    props.data.enable_queries,
+  ]);
 
   return (
     <>

--- a/src/components/Blocks/EmbedEEAMap/View.jsx
+++ b/src/components/Blocks/EmbedEEAMap/View.jsx
@@ -5,19 +5,19 @@ import { compose } from 'redux';
 
 import { PrivacyProtection } from '@eeacms/volto-embed';
 
-import { getContent } from '@plone/volto/actions';
 import Webmap from '@eeacms/volto-eea-map/components/Webmap';
 import ExtraViews from '@eeacms/volto-eea-map/components/ExtraViews';
 import { applyQueriesToMapLayers } from '@eeacms/volto-eea-map/utils';
+import { getVisualization } from '@eeacms/volto-eea-map/actions';
 
 const View = (props) => {
-  const { data, id, data_provenance = {} } = props || {};
+  const { data, data_provenance = {} } = props || {};
   const { height = '' } = data;
 
   const [mapData, setMapData] = React.useState('');
 
   React.useEffect(() => {
-    props.getContent(props.data.vis_url, null, id);
+    props.getVisualization(props.data.vis_url);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.data.vis_url]);
 
@@ -56,13 +56,15 @@ const View = (props) => {
 export default compose(
   connect(
     (state, props) => ({
-      data_provenance:
-        state.content.subrequests?.[props.id]?.data?.data_provenance,
-      map_visualization:
-        state.content.subrequests?.[props.id]?.data?.map_visualization_data,
+      map_visualization: props.data.vis_url
+        ? state.map_visualizations?.data[props.data.vis_url]?.data
+        : '',
+      data_provenance: props.data.vis_url
+        ? state.map_visualizations?.data[props.data.vis_url]?.data_provenance
+        : '',
     }),
     {
-      getContent,
+      getVisualization,
     },
   ),
 )(View);

--- a/src/components/Blocks/EmbedEEAMap/View.jsx
+++ b/src/components/Blocks/EmbedEEAMap/View.jsx
@@ -30,7 +30,11 @@ const View = (props) => {
 
     setMapData(updatedMapData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.map_visualization, props.data]);
+  }, [
+    props.map_visualization,
+    props.data.data_query_params,
+    props.data.enable_queries,
+  ]);
 
   return (
     <PrivacyProtection data={data} height={height} {...props}>

--- a/src/components/Webmap.jsx
+++ b/src/components/Webmap.jsx
@@ -30,9 +30,7 @@ const Webmap = (props) => {
     props.data.layers,
   ]);
   const base = React.useMemo(() => props?.data?.base || {}, [props.data.base]);
-  const legend = React.useMemo(() => props?.data?.legend || {}, [
-    props.data.legend,
-  ]);
+
   const general = React.useMemo(() => props?.data?.general || {}, [
     props.data.general,
   ]);
@@ -49,10 +47,6 @@ const Webmap = (props) => {
       .filter(({ map_layer }) => map_layer)
       .map((l, i) => l.map_layer);
 
-  const options = {
-    css: true,
-  };
-
   const mapRef = React.useRef();
   const [modules, setModules] = React.useState({});
 
@@ -61,7 +55,9 @@ const Webmap = (props) => {
   React.useEffect(() => {
     if (!modules_loaded.current) {
       modules_loaded.current = true;
-      loadModules(MODULES, options).then((modules) => {
+      loadModules(MODULES, {
+        css: true,
+      }).then((modules) => {
         const [
           Map,
           MapView,
@@ -92,7 +88,7 @@ const Webmap = (props) => {
         });
       });
     }
-  }, [setModules, options]);
+  }, [setModules]);
 
   var customFeatureLayerRenderer = {
     type: 'simple', // autocasts as new SimpleRenderer()
@@ -312,27 +308,6 @@ const Webmap = (props) => {
       });
       view.ui.add(zoomWidget, zoomPosition);
     }
-
-    if (legend?.legend?.show_legend) {
-      const legendPosition =
-        legend && legend.legend && legend.legend.position
-          ? legend.legend.position
-          : 'top-right';
-
-      const legendWidget = new Expand({
-        content: new Legend({
-          view: view,
-          style: 'classic',
-        }),
-        view: view,
-        expanded: false,
-        expandIconClass: 'esri-icon-legend',
-        expandTooltip: 'Legend',
-        classNames: 'some-cool-expand',
-      });
-      view.ui.add(legendWidget, legendPosition);
-    }
-
     const printPosition =
       general && general.print_position ? general.print_position : '';
 


### PR DESCRIPTION
Part of  https://taskman.eionet.europa.eu/issues/254131

Use eea.api.dataconnector dedicated `@map-visualization` endpoint for visualization data fetch, not volto `getContent`.