### PR TITLE
Map deep update multiple maps #254131

### DIFF
--- a/src/components/Blocks/EmbedEEAMap/Edit.jsx
+++ b/src/components/Blocks/EmbedEEAMap/Edit.jsx
@@ -9,12 +9,10 @@ import Webmap from '@eeacms/volto-eea-map/components/Webmap';
 import ExtraViews from '@eeacms/volto-eea-map/components/ExtraViews';
 
 import { Schema } from './Schema';
-import {
-  applyQueriesToMapLayers,
-  updateBlockQueryFromPageQuery,
-} from '@eeacms/volto-eea-map/utils';
+import { applyQueriesToMapLayers } from '@eeacms/volto-eea-map/utils';
 
 import { getVisualization } from '@eeacms/volto-eea-map/actions';
+import { deepUpdateDataQueryParams } from './helpers';
 
 const Edit = (props) => {
   const { block, data, onChangeBlock, selected, data_provenance = {} } = props;
@@ -22,58 +20,12 @@ const Edit = (props) => {
   const schema = Schema(props);
   const [mapData, setMapData] = React.useState('');
 
-  React.useEffect(() => {
-    if (!Object.hasOwn(data, 'show_legend')) {
-      onChangeBlock(block, {
-        ...data,
-        show_legend: true,
-      });
-    }
-    if (!Object.hasOwn(data, 'show_sources')) {
-      onChangeBlock(block, {
-        ...data,
-        show_sources: true,
-      });
-    }
-    if (!Object.hasOwn(data, 'dataprotection')) {
-      onChangeBlock(block, {
-        ...data,
-        dataprotection: { enabled: true },
-      });
-    }
-    //      eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.show_legend, data.show_sources, data.dataprotection]);
+  deepUpdateDataQueryParams(block, data, props.data_query, onChangeBlock);
 
   React.useEffect(() => {
     props.getVisualization(props.data.vis_url);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.data.vis_url]);
-
-  React.useEffect(() => {
-    if (props.data_query) {
-      //if block data_query_params do not exist, init them
-      if (!props?.data?.data_query_params) {
-        onChangeBlock(block, {
-          ...props.data,
-          data_query_params: [...props.data_query],
-        });
-      }
-
-      //if block data_query_params exist, deep check them then change them in block data
-      if (props?.data_query && data?.data_query_params) {
-        const newDataQuery = updateBlockQueryFromPageQuery(
-          props?.data_query,
-          data?.data_query_params,
-        );
-
-        onChangeBlock(block, {
-          ...data,
-          data_query_params: [...newDataQuery],
-        });
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.data_query]);
 
   React.useEffect(() => {
     const updatedMapData = applyQueriesToMapLayers(
@@ -84,11 +36,7 @@ const Edit = (props) => {
     setMapData(updatedMapData);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    props.map_visualization,
-    props.data.data_query_params,
-    props.data.enable_queries,
-  ]);
+  }, [props.map_visualization, props.data]);
 
   return (
     <>

--- a/src/components/Blocks/EmbedEEAMap/Edit.jsx
+++ b/src/components/Blocks/EmbedEEAMap/Edit.jsx
@@ -15,12 +15,14 @@ import { getVisualization } from '@eeacms/volto-eea-map/actions';
 import { deepUpdateDataQueryParams } from './helpers';
 
 const Edit = (props) => {
-  const { block, data, onChangeBlock, selected, data_provenance = {} } = props;
-  const { height = '' } = data;
+  const { block, onChangeBlock, selected, data_provenance = {} } = props;
   const schema = Schema(props);
   const [mapData, setMapData] = React.useState('');
+  const dataQuery = React.useMemo(() => props.data_query, [props.data_query]);
+  const data = React.useMemo(() => props.data, [props.data]);
+  const { height = '' } = data;
 
-  deepUpdateDataQueryParams(block, data, props.data_query, onChangeBlock);
+  deepUpdateDataQueryParams(block, data, dataQuery, onChangeBlock);
 
   React.useEffect(() => {
     props.getVisualization(props.data.vis_url);

--- a/src/components/Blocks/EmbedEEAMap/Edit.jsx
+++ b/src/components/Blocks/EmbedEEAMap/Edit.jsx
@@ -12,17 +12,13 @@ import { Schema } from './Schema';
 import { applyQueriesToMapLayers } from '@eeacms/volto-eea-map/utils';
 
 import { getVisualization } from '@eeacms/volto-eea-map/actions';
-import { deepUpdateDataQueryParams } from './helpers';
 
 const Edit = (props) => {
   const { block, onChangeBlock, selected, data_provenance = {} } = props;
   const schema = Schema(props);
   const [mapData, setMapData] = React.useState('');
-  const dataQuery = React.useMemo(() => props.data_query, [props.data_query]);
   const data = React.useMemo(() => props.data, [props.data]);
   const { height = '' } = data;
-
-  deepUpdateDataQueryParams(block, data, dataQuery, onChangeBlock);
 
   React.useEffect(() => {
     props.getVisualization(props.data.vis_url);

--- a/src/components/Blocks/EmbedEEAMap/Schema.js
+++ b/src/components/Blocks/EmbedEEAMap/Schema.js
@@ -1,3 +1,6 @@
+import React from 'react';
+import { deepUpdateDataQueryParams } from './helpers';
+
 const ProtectionSchema = () => ({
   title: 'Data Protection',
 
@@ -64,6 +67,12 @@ const ProtectionSchema = () => ({
 });
 
 export const Schema = (props) => {
+  const { block, onChangeBlock } = props;
+
+  const dataQuery = React.useMemo(() => props.data_query, [props.data_query]);
+  const data = React.useMemo(() => props.data, [props.data]);
+
+  deepUpdateDataQueryParams(block, data, dataQuery, onChangeBlock);
   return {
     title: 'Embed EEA Map Block',
     fieldsets: [

--- a/src/components/Blocks/EmbedEEAMap/Schema.js
+++ b/src/components/Blocks/EmbedEEAMap/Schema.js
@@ -102,10 +102,12 @@ export const Schema = (props) => {
         title: 'Show sources',
         description: 'Will show sources set in this page Data provenance',
         type: 'boolean',
+        defaultValue: true,
       },
       show_legend: {
         title: 'Show legend',
         type: 'boolean',
+        defaultValue: true,
       },
       show_viewer: {
         title: 'Show API link',
@@ -127,6 +129,7 @@ export const Schema = (props) => {
       dataprotection: {
         widget: 'object',
         schema: ProtectionSchema(),
+        default: { enabled: true },
       },
     },
     required: [],

--- a/src/components/Blocks/EmbedEEAMap/helpers.js
+++ b/src/components/Blocks/EmbedEEAMap/helpers.js
@@ -1,0 +1,30 @@
+import { updateBlockQueryFromPageQuery } from '@eeacms/volto-eea-map/utils';
+
+const deepUpdateDataQueryParams = (block, data, data_query, onChangeBlock) => {
+  // If block data_query_params do not exist, init them
+  if (!data?.data_query_params) {
+    onChangeBlock(block, {
+      ...data,
+      data_query_params: [...data_query],
+    });
+  }
+
+  // If block data_query_params exist, deep check them then change them in block data
+  if (data_query && data?.data_query_params) {
+    const newDataQuery = updateBlockQueryFromPageQuery(
+      data_query,
+      data?.data_query_params,
+    );
+
+    if (
+      JSON.stringify(newDataQuery) !== JSON.stringify(data.data_query_params)
+    ) {
+      onChangeBlock(block, {
+        ...data,
+        data_query_params: [...newDataQuery],
+      });
+    }
+  }
+};
+
+export { deepUpdateDataQueryParams };


### PR DESCRIPTION
- multiple onChangeBlock at the same time cannot be executed, therefore created a new way of autoupdating queries on edit block mount.
- better data memo for better performance
- use defaults in schema