### PR TITLE
fix: Remove async from preview_image middleware - refs #304013

### DIFF
--- a/src/middlewares/preview_image.js
+++ b/src/middlewares/preview_image.js
@@ -4,7 +4,7 @@ import {
 } from '@plone/volto/constants/ActionTypes';
 
 export const preview_image = (middlewares) => [
-  (store) => (next) => async (action) => {
+  (store) => (next) => (action) => {
     if (![CREATE_CONTENT, UPDATE_CONTENT].includes(action.type)) {
       return next(action);
     }


### PR DESCRIPTION
The `async` keyword on the `preview_image` Redux middleware created a new Promise wrapper around `next(action)`. When the `api` middleware's `actionPromise` rejected (e.g. 410 Gone on error pages), the `async` wrapper's Promise had no rejection handler, causing `unhandledrejection` events that were sent to Sentry.

## Root cause

The middleware chain is:

```
preview_image (async) → ... → api middleware
```

When a `GET_CONTENT` action fails (e.g. 410):

1. `api` middleware creates `actionPromise` (rejected), calls `.then(success, error)`, returns it
2. `async` `preview_image` does `return next(action)` — but because it's `async`, JS creates a **new Promise** that follows `actionPromise`
3. `api`'s `.then()` handles `actionPromise`'s rejection ✅
4. But the **new Promise** from the `async` wrapper has **no rejection handler** ❌
5. Browser fires `unhandledrejection` → Sentry captures it

## Fix

Remove the unnecessary `async` keyword. No `await` is used in the function, so `async` was not needed and caused this side effect.

## Testing

After this fix, navigating to 410 Gone / 404 Not Found / 401 Unauthorized pages no longer produces `Uncaught (in promise) Error: Gone/Not Found/Unauthorized` in the browser console or Sentry.

Related: eea/volto-eea-website-theme#385, eea/volto-embed#84